### PR TITLE
Auth handler for setting HttpOnly cookie

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,13 +115,13 @@ type SignerProxyConfig struct {
 type VerifierConfig struct {
 	Upstream        URL                          `yaml:"upstream"`
 	// Changed to string to be more JWT spec compliant - it can be either string or URL
-	Audience           string                       `yaml:"audience"`
-	MaxSkew            time.Duration                `yaml:"max_skew"`
-	MaxTTL             time.Duration                `yaml:"max_ttl"`
-	KeyServer          RegistrableComponentConfig   `yaml:"key_server"`
-	NonceStorage       RegistrableComponentConfig   `yaml:"nonce_storage"`
-	Excludes           []string                     `yaml:"excludes"`
-	ClaimsVerifiers    []RegistrableComponentConfig `yaml:"claims_verifiers"`
+	Audience         string                       `yaml:"audience"`
+	MaxSkew          time.Duration                `yaml:"max_skew"`
+	MaxTTL           time.Duration                `yaml:"max_ttl"`
+	KeyServer        RegistrableComponentConfig   `yaml:"key_server"`
+	NonceStorage     RegistrableComponentConfig   `yaml:"nonce_storage"`
+	Excludes         []string                     `yaml:"excludes"`
+	ClaimsVerifiers  []RegistrableComponentConfig `yaml:"claims_verifiers"`
 }
 
 type SignerParams struct {

--- a/config/config.go
+++ b/config/config.go
@@ -115,13 +115,14 @@ type SignerProxyConfig struct {
 type VerifierConfig struct {
 	Upstream        URL                          `yaml:"upstream"`
 	// Changed to string to be more JWT spec compliant - it can be either string or URL
-	Audience        string                       `yaml:"audience"`
-	MaxSkew         time.Duration                `yaml:"max_skew"`
-	MaxTTL          time.Duration                `yaml:"max_ttl"`
-	KeyServer       RegistrableComponentConfig   `yaml:"key_server"`
-	NonceStorage    RegistrableComponentConfig   `yaml:"nonce_storage"`
-	Excludes        []string                     `yaml:"excludes"`
-	ClaimsVerifiers []RegistrableComponentConfig `yaml:"claims_verifiers"`
+	Audience           string                       `yaml:"audience"`
+	MaxSkew            time.Duration                `yaml:"max_skew"`
+	MaxTTL             time.Duration                `yaml:"max_ttl"`
+	KeyServer          RegistrableComponentConfig   `yaml:"key_server"`
+	NonceStorage       RegistrableComponentConfig   `yaml:"nonce_storage"`
+	AuthServicePath    string                       `yaml:"auth_path"`
+	Excludes           []string                     `yaml:"excludes"`
+	ClaimsVerifiers    []RegistrableComponentConfig `yaml:"claims_verifiers"`
 }
 
 type SignerParams struct {

--- a/config/config.go
+++ b/config/config.go
@@ -120,7 +120,6 @@ type VerifierConfig struct {
 	MaxTTL             time.Duration                `yaml:"max_ttl"`
 	KeyServer          RegistrableComponentConfig   `yaml:"key_server"`
 	NonceStorage       RegistrableComponentConfig   `yaml:"nonce_storage"`
-	AuthServicePath    string                       `yaml:"auth_path"`
 	Excludes           []string                     `yaml:"excludes"`
 	ClaimsVerifiers    []RegistrableComponentConfig `yaml:"claims_verifiers"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -115,13 +115,13 @@ type SignerProxyConfig struct {
 type VerifierConfig struct {
 	Upstream        URL                          `yaml:"upstream"`
 	// Changed to string to be more JWT spec compliant - it can be either string or URL
-	Audience         string                       `yaml:"audience"`
-	MaxSkew          time.Duration                `yaml:"max_skew"`
-	MaxTTL           time.Duration                `yaml:"max_ttl"`
-	KeyServer        RegistrableComponentConfig   `yaml:"key_server"`
-	NonceStorage     RegistrableComponentConfig   `yaml:"nonce_storage"`
-	Excludes         []string                     `yaml:"excludes"`
-	ClaimsVerifiers  []RegistrableComponentConfig `yaml:"claims_verifiers"`
+	Audience        string                       `yaml:"audience"`
+	MaxSkew         time.Duration                `yaml:"max_skew"`
+	MaxTTL          time.Duration                `yaml:"max_ttl"`
+	KeyServer       RegistrableComponentConfig   `yaml:"key_server"`
+	NonceStorage    RegistrableComponentConfig   `yaml:"nonce_storage"`
+	Excludes        []string                     `yaml:"excludes"`
+	ClaimsVerifiers []RegistrableComponentConfig `yaml:"claims_verifiers"`
 }
 
 type SignerParams struct {

--- a/jwtproxy.go
+++ b/jwtproxy.go
@@ -120,7 +120,7 @@ func StartReverseProxy(rpConfig config.VerifierProxyConfig, stopper *stop.Group,
 	}
 
 	// Create reverse proxy.
-	reverseProxy, err := proxy.NewReverseProxy(verifier.Handler, proxier.Handler, auth.Handler, rpConfig.Verifier.AuthServicePath, excludes...)
+	reverseProxy, err := proxy.NewReverseProxy(verifier.Handler, proxier.Handler, auth.Handler, "/jwt/auth", excludes...)
 	if err != nil {
 		stopper.Add(verifier)
 		abort <- fmt.Errorf("Failed to create reverse proxy: %s", err)

--- a/jwtproxy.go
+++ b/jwtproxy.go
@@ -105,6 +105,9 @@ func StartReverseProxy(rpConfig config.VerifierProxyConfig, stopper *stop.Group,
 	//Create simple (non-verifying) handler
 	proxier, err := jwt.NewReverseProxyHandler(rpConfig.Verifier)
 
+	//Create auth handler
+	auth, err := jwt.NewAuthenticationHandler()
+
 	var excludes []*regexp.Regexp
 	for _, ex := range rpConfig.Verifier.Excludes {
 		regex, err := regexp.Compile(ex)
@@ -117,7 +120,7 @@ func StartReverseProxy(rpConfig config.VerifierProxyConfig, stopper *stop.Group,
 	}
 
 	// Create reverse proxy.
-	reverseProxy, err := proxy.NewReverseProxy(verifier.Handler, proxier.Handler, excludes...)
+	reverseProxy, err := proxy.NewReverseProxy(verifier.Handler, proxier.Handler, auth.Handler, rpConfig.Verifier.AuthServicePath, excludes...)
 	if err != nil {
 		stopper.Add(verifier)
 		abort <- fmt.Errorf("Failed to create reverse proxy: %s", err)


### PR DESCRIPTION
This PR adds hanler which allows to set cookie with machine token for the client side.
Token must be passed in `Authorization` header, then it being validated and 204 response with `HttpOnly` cookie containing that token returned.