### PR TITLE
Add CORS headers to auth service response

### DIFF
--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -214,6 +214,9 @@ func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler
 			}
 			resp = goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusNoContent, "")
 			cookie := http.Cookie{Name: "access_token", Value: token, HttpOnly: true, Path: "/"}
+			if Url.Scheme == "https" {
+				cookie.Secure = true
+			}
 			// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
 			resp.Header.Add("Set-Cookie", cookie.String())
 		}

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -187,20 +187,38 @@ func NewReverseProxyHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, 
 
 
 // Set cookie with token passed in authentication header
-func NewAuthenticationHandler() (*StoppableProxyHandler, error) {
+func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, error) {
 
 	stopper := stop.NewGroup()
 
+	var Url *url.URL
+	if cfg.AuthRedirect != "" {
+		tmp, err := url.Parse(cfg.AuthRedirect)
+		if err != nil {
+			return nil, errors.New("invalid auth redirect specified")
+		}
+		Url = tmp
+	}
+
 	// Create a reverse proxy.Handler that will proxy request to upstream
 	handler := func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		token, err := oidc.ExtractBearerToken(r)
-		if err != nil {
-			return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusForbidden, "No token found in request")
+		var resp *http.Response
+		if r.Method == "OPTIONS" {
+			resp = goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusOK, "")
+			resp.Header.Add("Access-Control-Allow-Headers", "authorization,origin,access-control-allow-origin,access-control-request-headers,content-type,access-control-request-method,accept")
+			resp.Header.Add("Access-Control-Allow-Methods", "GET")
+		} else {
+			token, err := oidc.ExtractBearerToken(r)
+			if err != nil {
+				return r, goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusForbidden, "No token found in request")
+			}
+			resp = goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusNoContent, "")
+			cookie := http.Cookie{Name: "access_token", Value: token, HttpOnly: true, Path: "/"}
+			// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
+			resp.Header.Add("Set-Cookie", cookie.String())
 		}
-		resp := goproxy.NewResponse(r, goproxy.ContentTypeText, http.StatusNoContent, "")
-		cookie := http.Cookie{Name: "access_token", Value: token, HttpOnly: true}
-		// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
-		resp.Header.Add("Set-Cookie", cookie.String())
+		resp.Header.Add("Access-Control-Allow-Origin", Url.Scheme + "://" + Url.Host)
+		resp.Header.Add("Access-Control-Allow-Credentials", "true")
 		return r, resp
 	}
 

--- a/jwtproxy.go
+++ b/jwtproxy.go
@@ -104,7 +104,7 @@ func StartReverseProxy(rpConfig config.VerifierProxyConfig, stopper *stop.Group,
 	proxier, err := jwt.NewReverseProxyHandler(rpConfig.Verifier)
 
 	//Create auth handler
-	auth, err := jwt.NewAuthenticationHandler()
+	auth, err := jwt.NewAuthenticationHandler(rpConfig.Verifier)
 
 	var excludes []*regexp.Regexp
 	for _, ex := range rpConfig.Verifier.Excludes {


### PR DESCRIPTION
Add CORS headers to auth service response since it will be requested from loader.html located in master, so CORS headers needed to allow JS to access to the returned cookes.