### PR TITLE
Added an ability to configure whether authentication via cookies is enabled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -116,6 +116,7 @@ type VerifierConfig struct {
 	Upstream        URL                          `yaml:"upstream"`
 	// Changed to string to be more JWT spec compliant - it can be either string or URL
 	Audience        string                       `yaml:"audience"`
+	CookiesEnabled  bool                         `yaml:"auth_cookies_enabled"`
 	AuthRedirect    string                       `yaml:"auth_redirect_url"`
 	MaxSkew         time.Duration                `yaml:"max_skew"`
 	MaxTTL          time.Duration                `yaml:"max_ttl"`

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -121,7 +121,7 @@ func Verify(req *http.Request, keyServer keyserver.Reader, nonceVerifier noncest
 		return nil, errors.New("Missing or invalid 'exp' claim")
 	}
 	if exp.Before(now) {
-		return  nil, &authRequiredError{"Token is expired", "http://" + req.Host + req.URL.String()}
+		return nil, &authRequiredError{"Token is expired", "http://" + req.Host + req.URL.String()}
 	}
 	nbf, exists, err := claims.TimeClaim("nbf")
 	if !exists || err != nil || nbf.After(now) {
@@ -167,7 +167,7 @@ func verifyAudience(actual string, expected string) bool {
 	if actualErr == nil && expectedErr == nil {
 		// both are URL's
 		return strings.EqualFold(actualURL.Scheme+"://"+actualURL.Host, expectedURL.Scheme+"://"+expectedURL.Host)
-	} else if actualErr != nil && expectedErr!= nil {
+	} else if actualErr != nil && expectedErr != nil {
 		// both are simple strings
 		return actual == expected
 	} else {
@@ -194,11 +194,10 @@ func generateNonce(n int) string {
 }
 
 type authRequiredError struct {
-	err         string
-	requestUri  string
+	err        string
+	requestUri string
 }
 
 func (e *authRequiredError) Error() string {
 	return e.err
 }
-

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -22,13 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-oidc/jose"
 	"github.com/coreos/go-oidc/key"
+	"github.com/coreos/go-oidc/oidc"
 	"github.com/eclipse/che-jwtproxy/config"
+	"github.com/eclipse/che-jwtproxy/jwt"
 	"github.com/eclipse/che-jwtproxy/stop"
 	"github.com/stretchr/testify/assert"
-	"github.com/eclipse/che-jwtproxy/jwt"
-	"github.com/coreos/go-oidc/oidc"
-	"github.com/coreos/go-oidc/jose"
 )
 
 const privateKey = `
@@ -45,7 +45,7 @@ im92fadzPg+oTXIQIjlHhGgf7CKb5VwFuH9+gA==
 
 type testService struct {
 	// privatekey
-	privkey        *key.PrivateKey
+	privkey *key.PrivateKey
 
 	// keyserver
 	issuer        string
@@ -81,7 +81,6 @@ func (ts *testService) Stop() <-chan struct{} {
 	return stop.AlreadyDone
 }
 
-
 func testData() (*http.Request, *signAndVerifyParams) {
 	// Create a request to sign.
 	req, _ := http.NewRequest("GET", "http://foo.bar:6666/ez", nil)
@@ -96,10 +95,10 @@ func testData() (*http.Request, *signAndVerifyParams) {
 
 	// Create a test service to act as a keyserver and as a privatekey provider.
 	services := &testService{
-		privkey:        pk,
-		issuer:         "issuer",
-		sendBadPubKey:  false,
-		refuseNonce:    false,
+		privkey:       pk,
+		issuer:        "issuer",
+		sendBadPubKey: false,
+		refuseNonce:   false,
 	}
 
 	// Create a default (and valid) configuration to sign and verify requests.
@@ -200,7 +199,6 @@ func TestEmptyAudience(t *testing.T) {
 	assert.Nil(t, Verify(req, *cfg))
 }
 
-
 func TestWrongTTL(t *testing.T) {
 	req, cfg := testData()
 	cfg.maxTTL = 30 * time.Second
@@ -261,7 +259,6 @@ type signAndVerifyParams struct {
 }
 
 type requestModifier func(req *http.Request)
-
 
 func signAndModify(t *testing.T, req *http.Request, p signAndVerifyParams, modify requestModifier) *http.Request {
 	// Sign.

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -111,9 +111,10 @@ func testData() (*http.Request, *signAndVerifyParams) {
 			MaxSkew:        1 * time.Minute,
 			NonceLength:    8,
 		},
-		aud:     aud,
-		maxSkew: time.Minute,
-		maxTTL:  5 * time.Minute,
+		aud:            aud,
+		maxSkew:        time.Minute,
+		maxTTL:         5 * time.Minute,
+		cookiesEnabled: true,
 	}
 
 	return req, defaultConfig
@@ -253,9 +254,10 @@ type signAndVerifyParams struct {
 	signerParams config.SignerParams
 
 	// Verify.
-	aud     string
-	maxSkew time.Duration
-	maxTTL  time.Duration
+	aud            string
+	maxSkew        time.Duration
+	maxTTL         time.Duration
+	cookiesEnabled bool
 }
 
 type requestModifier func(req *http.Request)
@@ -274,6 +276,6 @@ func signAndModify(t *testing.T, req *http.Request, p signAndVerifyParams, modif
 
 func Verify(req *http.Request, p signAndVerifyParams) error {
 	// Verify.
-	_, err := jwt.Verify(req, p.services, p.services, p.aud, p.maxSkew, p.maxTTL)
+	_, err := jwt.Verify(req, p.services, p.services, p.cookiesEnabled, p.aud, p.maxSkew, p.maxTTL)
 	return err
 }

--- a/jwt/noncestorage/void/void.go
+++ b/jwt/noncestorage/void/void.go
@@ -32,7 +32,7 @@ func init() {
 //        type: void
 // property.
 
-type Void struct {}
+type Void struct{}
 
 func constructor(registrableComponentConfig config.RegistrableComponentConfig) (noncestorage.NonceStorage, error) {
 	return &Void{}, nil

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -128,7 +128,7 @@ func NewJWTVerifierHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, e
 
 	// Create a reverse proxy.Handler that will verify JWT from http.Requests.
 	handler := func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		signedClaims, err := Verify(r, keyServer, nonceStorage, cfg.Audience, cfg.MaxSkew, cfg.MaxTTL)
+		signedClaims, err := Verify(r, keyServer, nonceStorage, cfg.CookiesEnabled, cfg.Audience, cfg.MaxSkew, cfg.MaxTTL)
 		if err != nil {
 			if authErr, ok := err.(*authRequiredError); ok {
 				if redirectUrl != nil {

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -25,6 +25,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/coreos/goproxy"
 
+	"github.com/coreos/go-oidc/oidc"
 	"github.com/eclipse/che-jwtproxy/config"
 	"github.com/eclipse/che-jwtproxy/jwt/claims"
 	"github.com/eclipse/che-jwtproxy/jwt/keyserver"
@@ -32,7 +33,6 @@ import (
 	"github.com/eclipse/che-jwtproxy/jwt/privatekey"
 	"github.com/eclipse/che-jwtproxy/proxy"
 	"github.com/eclipse/che-jwtproxy/stop"
-	"github.com/coreos/go-oidc/oidc"
 )
 
 type StoppableProxyHandler struct {
@@ -185,7 +185,6 @@ func NewReverseProxyHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, 
 	}, nil
 }
 
-
 // Set cookie with token passed in authentication header
 func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, error) {
 
@@ -220,7 +219,7 @@ func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler
 			// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
 			resp.Header.Add("Set-Cookie", cookie.String())
 		}
-		resp.Header.Add("Access-Control-Allow-Origin", Url.Scheme + "://" + Url.Host)
+		resp.Header.Add("Access-Control-Allow-Origin", Url.Scheme+"://"+Url.Host)
 		resp.Header.Add("Access-Control-Allow-Credentials", "true")
 		return r, resp
 	}

--- a/jwtproxy.go
+++ b/jwtproxy.go
@@ -117,8 +117,16 @@ func StartReverseProxy(rpConfig config.VerifierProxyConfig, stopper *stop.Group,
 		excludes = append(excludes, regex)
 	}
 
+	var authServicePath = ""
+	if rpConfig.Verifier.AuthRedirect != "" {
+		if !rpConfig.Verifier.CookiesEnabled {
+			log.Warn("Authentication service is configured to be deployed while authentication with cookies is disabled.")
+		}
+		authServicePath = "/jwt/auth"
+	}
+
 	// Create reverse proxy.
-	reverseProxy, err := proxy.NewReverseProxy(verifier.Handler, proxier.Handler, auth.Handler, "/jwt/auth", excludes...)
+	reverseProxy, err := proxy.NewReverseProxy(verifier.Handler, proxier.Handler, auth.Handler, authServicePath, excludes...)
 	if err != nil {
 		stopper.Add(verifier)
 		abort <- fmt.Errorf("Failed to create reverse proxy: %s", err)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -23,13 +23,13 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"time"
-	"regexp"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/eclipse/che-jwtproxy/stop"
 	"github.com/coreos/goproxy"
+	"github.com/eclipse/che-jwtproxy/stop"
 	"github.com/tylerb/graceful"
 )
 
@@ -135,7 +135,7 @@ func NewProxy(proxyHandler Handler, caKeyPath, caCertPath string, insecureSkipVe
 	return &Proxy{ProxyHttpServer: proxy}, nil
 }
 
-func NewReverseProxy(vefiyingHandler Handler, proxyHandler Handler, authHandler Handler, authServicePath string, excludes... *regexp.Regexp) (*Proxy, error) {
+func NewReverseProxy(vefiyingHandler Handler, proxyHandler Handler, authHandler Handler, authServicePath string, excludes ...*regexp.Regexp) (*Proxy, error) {
 	// Create a reverse proxy.
 	reverseProxy := goproxy.NewReverseProxyHttpServer()
 	reverseProxy.Tr = http.DefaultTransport.(*http.Transport)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -135,14 +135,14 @@ func NewProxy(proxyHandler Handler, caKeyPath, caCertPath string, insecureSkipVe
 	return &Proxy{ProxyHttpServer: proxy}, nil
 }
 
-func NewReverseProxy(vefiyingHandler Handler, proxyHandler Handler, authHandler Handler, authServicePath string, excludes ...*regexp.Regexp) (*Proxy, error) {
+func NewReverseProxy(verifyingHandler Handler, proxyHandler Handler, authHandler Handler, authServicePath string, excludes ...*regexp.Regexp) (*Proxy, error) {
 	// Create a reverse proxy.
 	reverseProxy := goproxy.NewReverseProxyHttpServer()
 	reverseProxy.Tr = http.DefaultTransport.(*http.Transport)
 	reverseProxy.Verbose = log.GetLevel() == log.DebugLevel
 
 	// Handle requests with the validation handler.
-	reverseProxy.OnRequest(goproxy.Not(IsCorsPreflight()), goproxy.Not(UrlMatches(excludes...))).DoFunc(vefiyingHandler)
+	reverseProxy.OnRequest(goproxy.Not(IsCorsPreflight()), goproxy.Not(UrlMatches(excludes...))).DoFunc(verifyingHandler)
 
 	if authServicePath != "" {
 		// Auth

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -12,15 +12,15 @@
 package proxy_test
 
 import (
-	"testing"
-	"net/http"
-	"github.com/stretchr/testify/assert"
 	"github.com/coreos/goproxy"
-	"regexp"
 	"github.com/eclipse/che-jwtproxy/proxy"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"regexp"
+	"testing"
 )
 
-var  ctx = &goproxy.ProxyCtx{}
+var ctx = &goproxy.ProxyCtx{}
 
 func TestIsCors(t *testing.T) {
 
@@ -42,11 +42,9 @@ func TestIsCors(t *testing.T) {
 	assert.False(t, preflightFunc(req4, ctx))
 }
 
-
-
 func TestUrlMatching(t *testing.T) {
 	var ExclusionTestRequests = []struct {
-		req     *http.Request
+		req      *http.Request
 		expected bool // expected result
 	}{
 		{getRequest("http://foo.bar:6666/ezz666"), false},
@@ -64,7 +62,6 @@ func TestUrlMatching(t *testing.T) {
 		assert.Equal(t, tt.expected, actual)
 	}
 }
-
 
 func getRequest(url string) *http.Request {
 	req, _ := http.NewRequest("GET", url, nil)


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is adding an ability to configure whether authentication via cookies is enabled.

Also, it contains the following small fixes:
- format source code with `gofmt`;
- fix typo in verifyingHandler var name;
- rename Url variable to redirectUrl to make it more self-explaining;
- do not deploy auth endpoint if redirect URL is not configured;

PR is supposed to be reviewed in a commit-by-commit manner.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10725