### PR TITLE
Allow the JWT proxy to redirect to `https` URLs, and not only to `http` URLs.

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -95,7 +95,7 @@ func Verify(req *http.Request, keyServer keyserver.Reader, nonceVerifier noncest
 
 	if token == "" {
 		// Not found anywhere
-		return nil, &authRequiredError{"No JWT found", "http://" + req.Host + req.URL.String()}
+		return nil, &authRequiredError{"No JWT found", req.URL.Scheme + "://" + req.Host + req.URL.String()}
 	}
 
 	// Parse token.
@@ -134,7 +134,7 @@ func Verify(req *http.Request, keyServer keyserver.Reader, nonceVerifier noncest
 		return nil, errors.New("Missing or invalid 'exp' claim")
 	}
 	if exp.Before(now) {
-		return nil, &authRequiredError{"Token is expired", "http://" + req.Host + req.URL.String()}
+		return nil, &authRequiredError{"Token is expired", req.URL.Scheme + "://" + req.Host + req.URL.String()}
 	}
 	nbf, exists, err := claims.TimeClaim("nbf")
 	if !exists || err != nil || nbf.After(now) {


### PR DESCRIPTION
### What does this PR do?

This allows the JWT proxy to redirect to `https` URLs, and not only to `http` URLs.
For this, when building the redirect URL, it reuses the initial request scheme instead of the fix `http` scheme.

### What issues does this PR fix or reference?

It should fix issue https://github.com/eclipse/che/issues/11664

### How was this PR tested

This PR wasn't tested for now.
