### PR TITLE
Support single-host mode of Che server.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,15 @@ jwtproxy:
       nonce_storage:
         type: <string|nil>
         options: <map[string]interface{}>
+
+      # a path on which the `access_token` cookie should be stored. This means that the browsers will only use the
+      # cookie on requests for URLs on the sub paths of the cookie_path.
+      cookie_path: <string|nil>
+
+      # In case the JWT proxy is placed behind a path-rewriting reverse proxy (such as Kubernetes Ingress)
+      # the value of this property can be used to modify the "apparent" path of the request as the JWT proxy
+      # sees it when composing the redirect to be used after the authentication request.
+      public_base_path: <string|nil>
 ```
 
 #### Key Registry Key Server

--- a/config/config.go
+++ b/config/config.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // URL is a custom URL type that allows validation at configuration load time.
@@ -113,17 +113,19 @@ type SignerProxyConfig struct {
 }
 
 type VerifierConfig struct {
-	Upstream        URL                          `yaml:"upstream"`
+	Upstream URL `yaml:"upstream"`
 	// Changed to string to be more JWT spec compliant - it can be either string or URL
-	Audience        string                       `yaml:"audience"`
-	CookiesEnabled  bool                         `yaml:"auth_cookies_enabled"`
-	AuthRedirect    string                       `yaml:"auth_redirect_url"`
-	MaxSkew         time.Duration                `yaml:"max_skew"`
-	MaxTTL          time.Duration                `yaml:"max_ttl"`
-	KeyServer       RegistrableComponentConfig   `yaml:"key_server"`
-	NonceStorage    RegistrableComponentConfig   `yaml:"nonce_storage"`
-	Excludes        []string                     `yaml:"excludes"`
-	ClaimsVerifiers []RegistrableComponentConfig `yaml:"claims_verifiers"`
+	Audience                   string                       `yaml:"audience"`
+	CookiesEnabled             bool                         `yaml:"auth_cookies_enabled"`
+	CookiePath                 string                       `yaml:"cookie_path"`
+	AuthRedirect               string                       `yaml:"auth_redirect_url"`
+	MaxSkew                    time.Duration                `yaml:"max_skew"`
+	MaxTTL                     time.Duration                `yaml:"max_ttl"`
+	KeyServer                  RegistrableComponentConfig   `yaml:"key_server"`
+	NonceStorage               RegistrableComponentConfig   `yaml:"nonce_storage"`
+	Excludes                   []string                     `yaml:"excludes"`
+	ClaimsVerifiers            []RegistrableComponentConfig `yaml:"claims_verifiers"`
+	AuthErrorRedirectURIPrefix string                       `yaml:"auth_error_redirect_uri_prefix"`
 }
 
 type SignerParams struct {

--- a/config/config.go
+++ b/config/config.go
@@ -115,17 +115,17 @@ type SignerProxyConfig struct {
 type VerifierConfig struct {
 	Upstream URL `yaml:"upstream"`
 	// Changed to string to be more JWT spec compliant - it can be either string or URL
-	Audience                   string                       `yaml:"audience"`
-	CookiesEnabled             bool                         `yaml:"auth_cookies_enabled"`
-	CookiePath                 string                       `yaml:"cookie_path"`
-	AuthRedirect               string                       `yaml:"auth_redirect_url"`
-	MaxSkew                    time.Duration                `yaml:"max_skew"`
-	MaxTTL                     time.Duration                `yaml:"max_ttl"`
-	KeyServer                  RegistrableComponentConfig   `yaml:"key_server"`
-	NonceStorage               RegistrableComponentConfig   `yaml:"nonce_storage"`
-	Excludes                   []string                     `yaml:"excludes"`
-	ClaimsVerifiers            []RegistrableComponentConfig `yaml:"claims_verifiers"`
-	AuthErrorRedirectURIPrefix string                       `yaml:"auth_error_redirect_uri_prefix"`
+	Audience        string                       `yaml:"audience"`
+	CookiesEnabled  bool                         `yaml:"auth_cookies_enabled"`
+	CookiePath      string                       `yaml:"cookie_path"`
+	AuthRedirect    string                       `yaml:"auth_redirect_url"`
+	MaxSkew         time.Duration                `yaml:"max_skew"`
+	MaxTTL          time.Duration                `yaml:"max_ttl"`
+	KeyServer       RegistrableComponentConfig   `yaml:"key_server"`
+	NonceStorage    RegistrableComponentConfig   `yaml:"nonce_storage"`
+	Excludes        []string                     `yaml:"excludes"`
+	ClaimsVerifiers []RegistrableComponentConfig `yaml:"claims_verifiers"`
+	PublicBasePath  string                       `yaml:"public_base_path"`
 }
 
 type SignerParams struct {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -276,6 +276,6 @@ func signAndModify(t *testing.T, req *http.Request, p signAndVerifyParams, modif
 
 func Verify(req *http.Request, p signAndVerifyParams) error {
 	// Verify.
-	_, err := jwt.Verify(req, p.services, p.services, p.cookiesEnabled, p.aud, p.maxSkew, p.maxTTL)
+	_, err := jwt.Verify(req, p.services, p.services, p.cookiesEnabled, p.aud, p.maxSkew, p.maxTTL, "")
 	return err
 }

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -128,7 +128,7 @@ func NewJWTVerifierHandler(cfg config.VerifierConfig) (*StoppableProxyHandler, e
 
 	// Create a reverse proxy.Handler that will verify JWT from http.Requests.
 	handler := func(r *http.Request, ctx *goproxy.ProxyCtx) (*http.Request, *http.Response) {
-		signedClaims, err := Verify(r, keyServer, nonceStorage, cfg.CookiesEnabled, cfg.Audience, cfg.MaxSkew, cfg.MaxTTL, cfg.AuthErrorRedirectURIPrefix)
+		signedClaims, err := Verify(r, keyServer, nonceStorage, cfg.CookiesEnabled, cfg.Audience, cfg.MaxSkew, cfg.MaxTTL, cfg.PublicBasePath)
 		if err != nil {
 			if authErr, ok := err.(*authRequiredError); ok {
 				if redirectUrl != nil {


### PR DESCRIPTION
### What does this PR do?
Support single-host mode of Che server.

* A custom URI prefix for the auth redirect can be configured. This is so
that we can construct valid externally reachable URLs even behind a
path-rewriting  ingress
* Change the order in which the auth token is located. First we try to
find it in the query params, then in the Authorization header as a bearer
token and only then in the cookie. This enables us to "refresh" the token
from the client side easily.
* On any error to validate the token (apart from the inability to parse the
token in the first place) we know send the auth redirect instead of an
error. This should help the client side refresh the token on timeouts, etc.
* Do not set the cookie in the response if cookies are not enabled in the
config.
* Respond with 403 - Forbidden if cookies are not enabled. In this case
the client needs to directly authenticate with the backend server.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14189