### PR TITLE
Change the path to the config to be in line with che server code.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo 
 
 
 FROM alpine:3.7
-ENV XDG_CONFIG_HOME=/config/
-VOLUME /config
+ENV XDG_CONFIG_HOME=/che-jwtproxy-config/
+VOLUME /che-jwtproxy-config
 COPY --from=builder /go/src/github.com/eclipse/che-jwtproxy/jwtproxy /usr/local/bin
 ENTRYPOINT ["jwtproxy"]
-CMD ["-config", "/config/config.yaml"]
+CMD ["-config", "/che-jwtproxy-config/config.yaml"]


### PR DESCRIPTION
### What does this PR do?
This puts the paths used in the dockerfile in line with the configuration produced by the Che server.

Note that this is a hotfix to enable correct function in restricted environments that don't tolerate skew between volume definitions in the image and the pods it is used in.

There will be a subsequent PR that will fix this as well and  will move all the configuration into the Che server and will make jwtproxy image just expect configuration coming from outside and not provide any defaults.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16112