### PR TITLE
Make the volume in the RHEL dockerfile point to the correct location.

### DIFF
--- a/rhel.Dockerfile
+++ b/rhel.Dockerfile
@@ -28,7 +28,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo 
 FROM registry.access.redhat.com/ubi8-minimal:8.1-328
 
 ENV XDG_CONFIG_HOME=/che-jwtproxy-config/
-VOLUME /config
+VOLUME /che-jwtproxy-config
 COPY --from=builder /go/src/github.com/eclipse/che-jwtproxy/jwtproxy /usr/local/bin
 ENTRYPOINT ["jwtproxy"]
 CMD ["-config", "/che-jwtproxy-config/config.yaml"]


### PR DESCRIPTION
### What does this PR do?
`$TITLE`. This is a minimal version of https://github.com/eclipse/che-jwtproxy/pull/20.
IMHO for the immediate future, we need the `Dockerfile` and `rhel.Dockerfile` inline and only then proceed with the larger changes that we agreed on in https://github.com/eclipse/che-jwtproxy/pull/20.

This PR makes `Dockerfile` and `rhel.Dockerfile` truly equivalent.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16129