### PR TITLE
Simplify the dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo 
 
 
 FROM alpine:3.7
-ENV XDG_CONFIG_HOME=/che-jwtproxy-config/
-VOLUME /che-jwtproxy-config
 COPY --from=builder /go/src/github.com/eclipse/che-jwtproxy/jwtproxy /usr/local/bin
 ENTRYPOINT ["jwtproxy"]
-CMD ["-config", "/che-jwtproxy-config/config.yaml"]
+# The JWT proxy needs 2 things:
+# * the location of the configuration file supplied as an argument:
+#   `-config <location/of/the/config.yaml>`
+# * The XDG_CONFIG_HOME environment variable pointing to a directory where to store auth keys
+# CMD ["-config", "/che-jwtproxy-config/config.yaml"]

--- a/rhel.Dockerfile
+++ b/rhel.Dockerfile
@@ -27,10 +27,12 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.1-328
 
-ENV XDG_CONFIG_HOME=/che-jwtproxy-config/
-VOLUME /che-jwtproxy-config
 COPY --from=builder /go/src/github.com/eclipse/che-jwtproxy/jwtproxy /usr/local/bin
 ENTRYPOINT ["jwtproxy"]
-CMD ["-config", "/che-jwtproxy-config/config.yaml"]
+# The JWT proxy needs 2 things:
+# * the location of the configuration file supplied as an argument:
+#   `-config <location/of/the/config.yaml>`
+# * The XDG_CONFIG_HOME environment variable pointing to a directory where to store auth keys
+# CMD ["-config", "/che-jwtproxy-config/config.yaml"]
 
 # append Brew metadata here


### PR DESCRIPTION
### What does this PR do?
Simplify the dockerfiles to not hardcode any volume, env vars or startup parameters. Rely on the runtime to provide this information and bind the volumes.

Note that this MUST NOT be merged before https://github.com/eclipse/che/pull/16227 is in che master otherwise JWT proxy will not be able to successfully authenticate.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/16227