### PR TITLE
Prevent endless redirections by adding SameSite cookie policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM golang:1.12 as builder
+FROM golang:1.10.3 as builder
 WORKDIR /go/src/github.com/eclipse/che-jwtproxy/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o jwtproxy cmd/jwtproxy/main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM golang:1.10.3 as builder
+FROM golang:1.13 as builder
 WORKDIR /go/src/github.com/eclipse/che-jwtproxy/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o jwtproxy cmd/jwtproxy/main.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM golang:1.13 as builder
+FROM golang:1.12 as builder
 WORKDIR /go/src/github.com/eclipse/che-jwtproxy/
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo -o jwtproxy cmd/jwtproxy/main.go

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -223,12 +223,15 @@ func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler
 			}
 
 			cookie := http.Cookie{Name: "access_token", Value: token, HttpOnly: true, Path: cookiePath}
+			var cookieString string
 			if redirectUrl.Scheme == "https" {
 				cookie.Secure = true
-				cookie.SameSite = http.SameSiteNoneMode
+				cookieString = cookie.String() + "; SameSite=None"
+			} else {
+			        cookieString = cookie.String()
 			}
 			// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
-			resp.Header.Add("Set-Cookie", cookie.String())
+			resp.Header.Add("Set-Cookie", cookieString)
 		}
 		resp.Header.Add("Access-Control-Allow-Origin", redirectUrl.Scheme+"://"+redirectUrl.Host)
 		resp.Header.Add("Access-Control-Allow-Credentials", "true")

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -226,7 +226,7 @@ func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler
 			var cookieString string
 			if redirectUrl.Scheme == "https" {
 				cookie.Secure = true
-				// Allow sending cookie to 3rd part context, see https://web.dev/samesite-cookies-explained/ and https://www.chromium.org/updates/same-site
+				// Allow sending cookie to 3rd party context, see https://web.dev/samesite-cookies-explained/ and https://www.chromium.org/updates/same-site
 				cookieString = cookie.String() + "; SameSite=None"
 			} else {
 			        cookieString = cookie.String() + "; SameSite=Lax"

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -226,9 +226,10 @@ func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler
 			var cookieString string
 			if redirectUrl.Scheme == "https" {
 				cookie.Secure = true
+				// Allow sending cookie to 3rd part context, see https://web.dev/samesite-cookies-explained/ and https://www.chromium.org/updates/same-site
 				cookieString = cookie.String() + "; SameSite=None"
 			} else {
-			        cookieString = cookie.String()
+			        cookieString = cookie.String() + "; SameSite=Lax"
 			}
 			// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
 			resp.Header.Add("Set-Cookie", cookieString)

--- a/jwt/proxy_handlers.go
+++ b/jwt/proxy_handlers.go
@@ -225,6 +225,7 @@ func NewAuthenticationHandler(cfg config.VerifierConfig) (*StoppableProxyHandler
 			cookie := http.Cookie{Name: "access_token", Value: token, HttpOnly: true, Path: cookiePath}
 			if redirectUrl.Scheme == "https" {
 				cookie.Secure = true
+				cookie.SameSite = http.SameSiteNoneMode
 			}
 			// workaround since cookies is not copied from response into writer, see proxy.go#ServeHTTP
 			resp.Header.Add("Set-Cookie", cookie.String())


### PR DESCRIPTION
### What does this PR do?
Prevent endless redirections  in newest Chrome versions by adding SameSite cookie policy
Situation was caused by changing requirements on `SameSite` and `Secure` cookie policies in Chrome browser (see https://www.chromium.org/updates/same-site for details), so auth cookie was rejected by browser and this caused redirections loop between loader and JWTProxy.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16384