### PR TITLE
To fix issue with /etc/passwd file in rhel.Dockerfile

### DIFF
--- a/build/dockerfiles/rhel.Dockerfile
+++ b/build/dockerfiles/rhel.Dockerfile
@@ -27,6 +27,7 @@ RUN adduser appuser && \
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.1-409
 USER appuser
+COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /go/src/github.com/eclipse/che-jwtproxy/jwtproxy /usr/local/bin
 ENTRYPOINT ["jwtproxy"]
 # The JWT proxy needs 2 things:


### PR DESCRIPTION
### What does this PR do?
Missing instruction in the rhel.Dockerfile is causing below issue while creating container:
Error: failed to start container "che-jwtproxyuz87ggs5": Error response from daemon: linux spec user: unable to find user appuser: no matching entries in passwd file.
This PR will fix this issue.

### What issues does this PR fix or reference?

Signed-off-by: vikas kumar kumar.vikas@in.ibm.com
