### PR TITLE
chore: Rename CI latest build to next build

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -78,7 +78,7 @@ jobs:
           DOCKER_IMAGE=${DOCKER_IMAGE:-$GITHUB_REPOSITORY}
           DOCKER_REPO=${{secrets.DOCKER_REPO}}
           DOCKER_PLATFORMS=linux/amd64,linux/s390x,linux/arm64,linux/ppc64le
-          VERSION=latest
+          VERSION=next
 
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Change the CI "latest" tags to "next and rename the job like in other Eclipse Che projects

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19291