### PR TITLE
fix: update next build job triggers and runner

### DIFF
--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -15,7 +15,7 @@ name: build
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'v*'
     tags:
       - 'v*'
@@ -23,7 +23,7 @@ on:
       - '**.md'
   pull_request:
     branches:
-      - 'master'
+      - 'main'
       - 'v*'
     paths-ignore:
       - '**.md'
@@ -31,7 +31,7 @@ on:
 jobs:
 
   go:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       -
         name: Checkout


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Fix next build job not triggering on main branch pushes, also update runner version to fixed 20.04 version

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/20516