### PR TITLE
chore: update gh actions to use Node 16 task versions and Ubuntu 22.04

### DIFF
--- a/.github/workflows/dependencies-md-check.yaml
+++ b/.github/workflows/dependencies-md-check.yaml
@@ -14,10 +14,10 @@ on: pull_request
 jobs:
   dependencies-md-check:
     name: DEPENDENCIES.md file validation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: DEPENDENCIES.md file validator.
       uses: che-incubator/dependencies-license-action@0.0.2
       env:

--- a/.github/workflows/make-branch.yaml
+++ b/.github/workflows/make-branch.yaml
@@ -15,9 +15,9 @@ on:
 jobs:
   build:
     name: Create branch
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           fetch-depth: 0
       - name: Create branch

--- a/.github/workflows/next-build.yml
+++ b/.github/workflows/next-build.yml
@@ -31,11 +31,11 @@ on:
 jobs:
 
   go:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
       -
         name: Prepare
         id: prepare
@@ -45,12 +45,12 @@ jobs:
           fi
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.13
       -
         name: Cache Go modules
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
@@ -63,12 +63,12 @@ jobs:
         name: Go test
         run: go test -v  ./...
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: go
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v3
       -
         name: Prepare
         id: prepare


### PR DESCRIPTION
Signed-off-by: sdawley <sdawley@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->
### What does this PR do?
Updates GitHub actions to use task versions updated with Node 16.
Updates to Ubuntu 22.04

### What issues does this PR fix or reference?
 Che Issue: https://github.com/eclipse/che/issues/21763